### PR TITLE
[IS-957] Log object and hash change that triggers rollout (WIP)

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 5
+	const timeout = time.Second * 10
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Deployment controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 5
+	const timeout = time.Second * 10
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 5
+	const timeout = time.Second * 10
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference

--- a/pkg/core/handler.go
+++ b/pkg/core/handler.go
@@ -113,6 +113,7 @@ func (h *Handler) handlePodController(instance podController) (reconcile.Result,
 
 	err = h.initialiseHashBank(instance.GetName(), current)
 	if err != nil {
+		fmt.Printf("error initialising hashbank: %v", err)
 		return reconcile.Result{}, fmt.Errorf("error initialising hashbank for %s: %v", instance.GetName(), err)
 	}
 	log.V(0).Info("Hashbank Initialised for podController", instance.GetName())
@@ -135,16 +136,19 @@ func (h *Handler) handlePodController(instance podController) (reconcile.Result,
 		// retrieve the hashes of the children
 		oldHashes, err := h.retrieveFromHashBank(current)
 		if err != nil {
+			fmt.Printf("error retrieving old hashes: %v", err)
 			return reconcile.Result{}, fmt.Errorf("Error retrieving from hashbank: %v", err)
 		}
 
 		// calculate the new hashes of the children, update hashbank
 		err = h.calculateNewHashBankEntries(instance.GetName(), current)
 		if err != nil {
+			fmt.Printf("error calculating new hashes: %v", err)
 			return reconcile.Result{}, fmt.Errorf("Error calculating new hash bank entires for %s: %v", instance.GetName(), err)
 		}
 		newHashes, err := h.retrieveFromHashBank(current)
 		if err != nil {
+			fmt.Printf("error retrieving new hashes: %v", err)
 			return reconcile.Result{}, fmt.Errorf("Error retrieving from hashbank: %v", err)
 		}
 
@@ -154,9 +158,9 @@ func (h *Handler) handlePodController(instance podController) (reconcile.Result,
 		for objectName, hash1 := range oldHashes {
 			if hash2, ok := newHashes[objectName]; ok {
 				if hash2 != hash1 {
-					fmt.Printf("Hashes for key %s differ: %s:%s", objectName, hash1, hash2)
+					fmt.Printf("Hashes for key %s differ: %s:%s\n", objectName, hash1, hash2)
 					log.V(0).Info("Hashes differ for object", "object", objectName, "hash1", hash1, "hash2", hash2)
-					h.recorder.Eventf(copy.GetObject(), corev1.EventTypeNormal, "RolloutTriggered", "A rollout was triggered by %s changing", objectName)
+					// h.recorder.Eventf(copy.GetObject(), corev1.EventTypeNormal, "RolloutTriggered", "A rollout was triggered by %s changing", objectName)
 				}
 			}
 		}

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Wave controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 5
+	const timeout = time.Second * 10
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference
@@ -379,7 +379,7 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, 2*timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Wave controller Suite", func() {
 					})
 
 					It("Updates the config hash in the Pod Template", func() {
-						m.Eventually(deployment, timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
+						m.Eventually(deployment, 2*timeout).ShouldNot(utils.WithPodTemplateAnnotations(HaveKeyWithValue(ConfigHashAnnotation, originalHash)))
 					})
 				})
 

--- a/pkg/core/hash.go
+++ b/pkg/core/hash.go
@@ -63,6 +63,96 @@ func calculateConfigHash(children []configObject) (string, error) {
 	return fmt.Sprintf("%x", hashBytes), nil
 }
 
+// updateHashBank stores hashes of each child in the in memory hashbank. It is
+// not threadsafe, and not to be called other than by a helper function.  as the
+// children should be uniquely named within the namespace it does not store the
+// instance name.
+func (h *Handler) updateHashBank(children []configObject) error {
+	// Add the hashes of each childs data to the hashBank
+	for _, child := range children {
+		if child.object != nil {
+			switch child.object.(type) {
+			case *corev1.ConfigMap:
+				hash, err := hashData(getConfigMapData(child))
+				if err != nil {
+					// log event and continue?
+					// return the error?
+				}
+				h.store.Bank[child.object.GetName()] = hashEntry{hash}
+			case *corev1.Secret:
+				hash, err := hashData(getSecretData(child))
+				if err != nil {
+					// log event and continue?
+				}
+				h.store.Bank[child.object.GetName()] = hashEntry{hash}
+			default:
+				return fmt.Errorf("passed unknown type: %v", reflect.TypeOf(child))
+			}
+		}
+	}
+	return nil
+}
+
+// initialiseHashBank checks if the instanceName exists in the hashBank, if not
+// it calls updateHashBank on the children.
+func (h *Handler) initialiseHashBank(instanceName string, children []configObject) error {
+	h.store.Lock()
+	defer h.store.Unlock()
+	if h.store.Bank == nil {
+		h.store.Bank = make(map[string]hashEntry)
+	}
+	if h.store.initialised == nil {
+		h.store.initialised = make(map[string]bool)
+	}
+
+	if _, ok := h.store.initialised[instanceName]; !ok {
+		err := h.updateHashBank(children)
+		if err != nil {
+			return err
+		}
+		h.store.initialised[instanceName] = true
+	}
+	return nil
+}
+
+// retrieveFromHashBank returns a map of objectName:hash for all children provided
+func (h *Handler) retrieveFromHashBank(children []configObject) (map[string]string, error) {
+	h.store.RLock()
+	defer h.store.RUnlock()
+	output := make(map[string]string)
+
+	// Retrieve the hashes of each childs data to the hashBank
+	for _, child := range children {
+		if child.object != nil {
+			switch child.object.(type) {
+			case *corev1.ConfigMap:
+				shaEntry := h.store.Bank[child.object.GetName()]
+				output[child.object.GetName()] = shaEntry.entry
+			case *corev1.Secret:
+				shaEntry := h.store.Bank[child.object.GetName()]
+				output[child.object.GetName()] = shaEntry.entry
+			default:
+				return output, fmt.Errorf("passed unknown type: %v", reflect.TypeOf(child))
+			}
+		}
+	}
+	return output, nil
+
+}
+
+// calculateNewHashBankEntries updates the hashbank given a new set of children
+func (h *Handler) calculateNewHashBankEntries(instanceName string, children []configObject) error {
+	h.store.Lock()
+	defer h.store.Unlock()
+	if _, ok := h.store.initialised[instanceName]; ok {
+		err := h.updateHashBank(children)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // getConfigMapData extracts all the relevant data from the ConfigMap, whether that is
 // the whole ConfigMap or only the specified keys.
 func getConfigMapData(child configObject) map[string]string {
@@ -109,4 +199,15 @@ func setConfigHash(obj podController, hash string) {
 	annotations[ConfigHashAnnotation] = hash
 	podTemplate.SetAnnotations(annotations)
 	obj.SetPodTemplate(podTemplate)
+}
+
+// hashData takes input and returns sha256'd output.
+func hashData(data interface{}) (string, error) {
+	structured, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("unable to marshal JSON: %v", err)
+	}
+
+	hashBytes := sha256.Sum256(structured)
+	return fmt.Sprintf("%x", hashBytes), nil
 }


### PR DESCRIPTION
WISOTT

This PR adds an in memory store for all child objects: A `HashBank`. When the `podController` instance hash changes this store is retrieved, updated and then diffed in order to determine which child object caused the `podController` instance hash to change.

Work in progress. 