### PR TITLE
Improve Test Stability Post-Migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,6 @@ jobs:
         working-directory: ./src/github.com/${{ github.repository }}
       - name: Run Tests
         run: |
-          export KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT=true
           export GOPATH=$(go env GOPATH):$(pwd)
           cd ./src/github.com/${{ github.repository }}
           make check

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cover.out
 wave
 **/.DS_Store
 kubebuilder
+*.code-workspace

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1147,7 +1147,7 @@
   revision = "3dccf664f023863740c508fb4284e49742bedfa4"
 
 [[projects]]
-  digest = "1:e04d03de743245cb462e5378fee8c7ffd4e7f08aa7871d6fe78d33f19351cebc"
+  digest = "1:6207ac3eaebcea768da2fffc662c49082bea25f4631806ecee7a39b622afd2e0"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -1185,8 +1185,8 @@
     "pkg/webhook/internal/metrics",
   ]
   pruneopts = "T"
-  revision = "aaddbd9d9a89d8ff329a084aece23be0406e6467"
-  version = "v0.2.0-beta.4"
+  revision = "fc5542c693e3340f8abbe91c6345bd64c494a60c"
+  version = "v0.2.2"
 
 [[projects]]
   digest = "1:2aec1bbf1553a2d433b3a85f9359930655de83e2dceed4aca44577a720396da8"
@@ -1239,6 +1239,7 @@
     "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/types",
+    "github.com/prometheus/client_golang/prometheus",
     "github.com/spf13/pflag",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
@@ -1260,6 +1261,7 @@
     "sigs.k8s.io/controller-runtime/pkg/envtest",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/metrics",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,8 @@ revision="0689ccc1d7d65d9dd1bedcc3b0b1ed7df91ba266"
 
 [[override]]
 name="sigs.k8s.io/controller-runtime"
-version="v0.2.0-beta.4"
+# version="v0.2.0-beta.4"
+version="v0.2.2"
 
 [[override]]
 name="sigs.k8s.io/controller-tools"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .env
 
 BINARY := wave
 VERSION := $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
-ECHO := echo -e
+ECHO := echo
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/wave-k8s/wave
@@ -83,8 +83,7 @@ check: fmt lint vet test
 .PHONY: test
 test: vendor generate manifests
 	@ $(ECHO) "\033[36mRunning test suite in Ginkgo\033[0m"
-#	$(GINKGO) -v -race -randomizeAllSpecs ./pkg/... ./cmd/... -- -report-dir=$$ARTIFACTS
-	$(GINKGO) -v -race -p ./pkg/... ./cmd/... -- -report-dir=$$ARTIFACTS
+	$(GINKGO) -v -randomizeAllSpecs ./pkg/... ./cmd/... -- -report-dir=$$ARTIFACTS
 	@ $(ECHO)
 
 # Build manager binary

--- a/pkg/controller/daemonset/daemonset_controller_suite_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_suite_test.go
@@ -79,9 +79,9 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		defer GinkgoRecover()
-		wg.Add(1)
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 		wg.Done()
 	}()

--- a/pkg/controller/deployment/deployment_controller_suite_test.go
+++ b/pkg/controller/deployment/deployment_controller_suite_test.go
@@ -78,9 +78,9 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		defer GinkgoRecover()
-		wg.Add(1)
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 		wg.Done()
 	}()

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -47,7 +48,7 @@ var _ = Describe("Deployment controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 120
+	const timeout = time.Second * 5
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference
@@ -79,7 +80,9 @@ var _ = Describe("Deployment controller Suite", func() {
 			MetricsBindAddress: "0",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		c = mgr.GetClient()
+		var cerr error
+		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(cerr).NotTo(HaveOccurred())
 		m = utils.Matcher{Client: c}
 
 		var recFn reconcile.Reconciler

--- a/pkg/controller/statefulset/statefulset_controller_suite_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_suite_test.go
@@ -80,9 +80,9 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		defer GinkgoRecover()
-		wg.Add(1)
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 		wg.Done()
 	}()

--- a/pkg/controller/statefulset/statefulset_controller_suite_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_suite_test.go
@@ -57,6 +57,7 @@ var _ = BeforeSuite(func() {
 	if cfg, err = t.Start(); err != nil {
 		log.Fatal(err)
 	}
+
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -47,7 +48,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 120
+	const timeout = time.Second * 5
 	const consistentlyTimeout = time.Second
 
 	var ownerRef metav1.OwnerReference
@@ -79,7 +80,11 @@ var _ = Describe("StatefulSet controller Suite", func() {
 			MetricsBindAddress: "0",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		c = mgr.GetClient()
+
+		var cerr error
+		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(cerr).NotTo(HaveOccurred())
+
 		m = utils.Matcher{Client: c}
 
 		var recFn reconcile.Reconciler

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -41,7 +42,7 @@ var _ = Describe("Wave children Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 120
+	const timeout = time.Second * 5
 
 	var cm1 *corev1.ConfigMap
 	var cm2 *corev1.ConfigMap
@@ -57,7 +58,9 @@ var _ = Describe("Wave children Suite", func() {
 			MetricsBindAddress: "0",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		c = mgr.GetClient()
+		var cerr error
+		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(cerr).NotTo(HaveOccurred())
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))
 		m = utils.Matcher{Client: c}
 

--- a/pkg/core/children_test.go
+++ b/pkg/core/children_test.go
@@ -61,7 +61,10 @@ var _ = Describe("Wave children Suite", func() {
 		var cerr error
 		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 		Expect(cerr).NotTo(HaveOccurred())
-		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))
+		c = mgr.GetClient()
+		//		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))
+		h = NewHandler(mgr.GetClient(), mgr.GetEventRecorderFor("wave"))
+
 		m = utils.Matcher{Client: c}
 
 		// Create some configmaps and secrets

--- a/pkg/core/delete_test.go
+++ b/pkg/core/delete_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -43,7 +44,7 @@ var _ = Describe("Wave owner references Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 120
+	const timeout = time.Second * 5
 
 	var ownerRef metav1.OwnerReference
 
@@ -52,7 +53,9 @@ var _ = Describe("Wave owner references Suite", func() {
 			MetricsBindAddress: "0",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		c = mgr.GetClient()
+		var cerr error
+		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(cerr).NotTo(HaveOccurred())
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))
 		m = utils.Matcher{Client: c}
 

--- a/pkg/core/hash_test.go
+++ b/pkg/core/hash_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wave-k8s/wave/test/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -37,7 +38,7 @@ var _ = Describe("Wave hash Suite", func() {
 		var mgrStopped *sync.WaitGroup
 		var stopMgr chan struct{}
 
-		const timeout = time.Second * 120
+		const timeout = time.Second * 5
 
 		var cm1 *corev1.ConfigMap
 		var cm2 *corev1.ConfigMap
@@ -53,7 +54,9 @@ var _ = Describe("Wave hash Suite", func() {
 				MetricsBindAddress: "0",
 			})
 			Expect(err).NotTo(HaveOccurred())
-			c = mgr.GetClient()
+			var cerr error
+			c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+			Expect(cerr).NotTo(HaveOccurred())
 			m = utils.Matcher{Client: c}
 
 			stopMgr, mgrStopped = StartTestManager(mgr)

--- a/pkg/core/owner_references_test.go
+++ b/pkg/core/owner_references_test.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -39,7 +40,7 @@ var _ = Describe("Wave owner references Suite", func() {
 	var mgrStopped *sync.WaitGroup
 	var stopMgr chan struct{}
 
-	const timeout = time.Second * 120
+	const timeout = time.Second * 5
 	const consistentlyTimeout = time.Second
 
 	var cm1 *corev1.ConfigMap
@@ -55,7 +56,9 @@ var _ = Describe("Wave owner references Suite", func() {
 			MetricsBindAddress: "0",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		c = mgr.GetClient()
+		var cerr error
+		c, cerr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(cerr).NotTo(HaveOccurred())
 		h = NewHandler(c, mgr.GetEventRecorderFor("wave"))
 		m = utils.Matcher{Client: c}
 

--- a/pkg/core/wave_suite_test.go
+++ b/pkg/core/wave_suite_test.go
@@ -78,9 +78,9 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 func StartTestManager(mgr manager.Manager) (chan struct{}, *sync.WaitGroup) {
 	stop := make(chan struct{})
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		defer GinkgoRecover()
-		wg.Add(1)
 		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
 		wg.Done()
 	}()

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -33,7 +33,6 @@ import (
 
 // Matcher has Gomega Matchers that use the controller-runtime client
 type Matcher struct {
-	//	Cfg    *rest.Config
 	Client client.Client
 }
 
@@ -144,6 +143,8 @@ func (m *Matcher) eventuallyObject(obj Object, intervals ...interface{}) gomega.
 			u = &appsv1.Deployment{}
 		case *appsv1.DaemonSet:
 			u = &appsv1.DaemonSet{}
+		default:
+			panic("Unknown Object type.")
 		}
 
 		err := m.Client.Get(context.TODO(), key, u)
@@ -167,6 +168,8 @@ func (m *Matcher) eventuallyList(obj runtime.Object, intervals ...interface{}) g
 			u = &corev1.SecretList{}
 		case *corev1.ConfigMapList:
 			u = &corev1.ConfigMapList{}
+		default:
+			panic("Unknown List type.")
 		}
 		err := m.Client.List(context.TODO(), u)
 		if err != nil {

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -159,11 +159,20 @@ func (m *Matcher) eventuallyObject(obj Object, intervals ...interface{}) gomega.
 // eventuallyList gets a list type  from the API server
 func (m *Matcher) eventuallyList(obj runtime.Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
 	list := func() runtime.Object {
-		err := m.Client.List(context.TODO(), obj)
+		var u runtime.Object
+		switch obj.(type) {
+		case *corev1.EventList:
+			u = &corev1.EventList{}
+		case *corev1.SecretList:
+			u = &corev1.SecretList{}
+		case *corev1.ConfigMapList:
+			u = &corev1.ConfigMapList{}
+		}
+		err := m.Client.List(context.TODO(), u)
 		if err != nil {
 			panic(err)
 		}
-		return obj
+		return u
 	}
 	return gomega.Eventually(list, intervals...)
 }

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -22,6 +22,8 @@ import (
 	"github.com/onsi/gomega"
 	gtypes "github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +33,7 @@ import (
 
 // Matcher has Gomega Matchers that use the controller-runtime client
 type Matcher struct {
+	//	Cfg    *rest.Config
 	Client client.Client
 }
 
@@ -122,16 +125,33 @@ func (m *Matcher) Eventually(obj runtime.Object, intervals ...interface{}) gomeg
 
 // eventuallyObject gets an individual object from the API server
 func (m *Matcher) eventuallyObject(obj Object, intervals ...interface{}) gomega.GomegaAsyncAssertion {
+
 	key := types.NamespacedName{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
 	}
+
 	get := func() Object {
-		err := m.Client.Get(context.TODO(), key, obj)
+		var u Object
+		switch obj.(type) {
+		case *appsv1.StatefulSet:
+			u = &appsv1.StatefulSet{}
+		case *corev1.ConfigMap:
+			u = &corev1.ConfigMap{}
+		case *corev1.Secret:
+			u = &corev1.Secret{}
+		case *appsv1.Deployment:
+			u = &appsv1.Deployment{}
+		case *appsv1.DaemonSet:
+			u = &appsv1.DaemonSet{}
+		}
+
+		err := m.Client.Get(context.TODO(), key, u)
 		if err != nil {
 			panic(err)
 		}
-		return obj
+
+		return u
 	}
 	return gomega.Eventually(get, intervals...)
 }


### PR DESCRIPTION
Reusing the object reference passed into `utils.eventuallyObject()` creates a race condition inside the client, resulting in stale or incomplete data being compared in the matcher.

This PR aims to fix this by creating a fresh struct each time and using a non-caching `client.Client` in all tests.

Also included: update controller-runtime to 0.2.2 for good measure as well as reverting all `Eventually()` timeouts to the original 5s.

EDIT:
After more debugging it turns out that something about testenv or the way we're using it is inherently not thread-safe.
Tests are reliable only when running them without `-p`.
I have confirmed that this problem is confined to testenv and not the code under test.
Thus, for now and going forward tests will run without `-p`.