### PR TITLE
charts: use rbac v1 api

### DIFF
--- a/charts/wave/templates/clusterrole.yaml
+++ b/charts/wave/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/wave/templates/clusterrolebinding.yaml
+++ b/charts/wave/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Add support for Kubernetes 1.22. The v1 API has been supported since 1.17.