### PR TITLE
Add support for defining additional volumes

### DIFF
--- a/charts/wave/templates/deployment.yaml
+++ b/charts/wave/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           {{- if .Values.syncPeriod }}
             - --sync-period={{ .Values.syncPeriod }}
           {{- end }}
+          volumeMounts: {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "wave-fullname" .) }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      volumes: {{ toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/wave/values.yaml
+++ b/charts/wave/values.yaml
@@ -20,6 +20,16 @@ nodeSelector: {}
 # Replicas > 1 will enable leader election
 replicas: 1
 
+# Additional volumes to use in the pod.
+extraVolumes: []
+# - name: tmp
+#   emptyDir: {}
+
+# Additional volumes to mount into the container.
+extraVolumeMounts: []
+# - name: tmp
+#   mountPath: /tmp
+
 # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
Our clusters apply restricted PSPs that make the root filesystem read-only.  In such cases, the application crashes when trying to write to `/tmp`.  The feature enabled by this PR allows us to mount an emptyDir volume at `/tmp` to work around the restriction.