### PR TITLE
Change authorization api version for kube 1.22 compatibility

### DIFF
--- a/charts/wave/templates/clusterrole.yaml
+++ b/charts/wave/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/wave/templates/clusterrolebinding.yaml
+++ b/charts/wave/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Fix api version to be kubernetes 1.22 compatibility
changed `authorization.k8s.io/v1beta1` to `authorization.k8s.io/v1` as it's available since kubernetes 1.19