### PR TITLE
remove the ignore-paths for the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Run tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-    - README.md
-    - LICENSE.md
   push:
     branches:
     - master


### PR DESCRIPTION
since the tests are required for PR merging, we need to run them for every PR