### PR TITLE
Helm chart improvements (PodDisruptionBudget and topologySpreadConstraints)

### DIFF
--- a/charts/wave/Chart.yaml
+++ b/charts/wave/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: wave
 description: wave chart that runs on kubernetes
 version: 3.0.0

--- a/charts/wave/templates/deployment.yaml
+++ b/charts/wave/templates/deployment.yaml
@@ -39,4 +39,5 @@ spec:
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
       volumes: {{ toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/wave/templates/poddisruptionbudget.yaml
+++ b/charts/wave/templates/poddisruptionbudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wave-fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "wave.selectorLabels" . | nindent 6}}
+  maxUnavailable: 1
+{{- end }}

--- a/charts/wave/values.yaml
+++ b/charts/wave/values.yaml
@@ -58,8 +58,14 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# node tolerations for wave pod
 tolerations: []
 
+# (anti-)affinity for wave pods
 affinity: {}
 
+# topologySpreadConstraints for the wave pods
+topologySpreadConstraints: []
+
+# extra annotations for wave pods
 podAnnotations: {}

--- a/charts/wave/values.yaml
+++ b/charts/wave/values.yaml
@@ -20,6 +20,10 @@ nodeSelector: {}
 # Replicas > 1 will enable leader election
 replicas: 1
 
+# Add PodDisruptionBudget which should be enabled for replicas > 1
+pdb:
+  enabled: false
+
 # Additional volumes to use in the pod.
 extraVolumes: []
 # - name: tmp


### PR DESCRIPTION
- Add (optional) PodDisruptionBudget
- Add (optional) topologySpreadConstraints
- Bump Chart Version to v2 (Helm 3) since Helm 2 has been unsupported since end of 2020