### PR TITLE
Mutating webhooks

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,6 +10,9 @@ jobs:
         version:
           - v1.21
           - v1.29
+        setup:
+          - minimal
+          - production
     runs-on: ubuntu-latest
     name: test on minikube
     steps:
@@ -19,4 +22,4 @@ jobs:
         with:
           kubernetes-version: ${{ matrix.version }}
       - name: Build and run wave
-        run: hack/run-test-in-minikube.sh
+        run: hack/run-test-in-minikube.sh ${{ matrix.setup }}

--- a/charts/wave/templates/clusterrole.yaml
+++ b/charts/wave/templates/clusterrole.yaml
@@ -37,4 +37,10 @@ rules:
       - update
       - patch
       - watch
+  - verbs:
+      - '*'
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
 {{- end }}

--- a/charts/wave/templates/deployment.yaml
+++ b/charts/wave/templates/deployment.yaml
@@ -32,12 +32,36 @@ spec:
           {{- if .Values.syncPeriod }}
             - --sync-period={{ .Values.syncPeriod }}
           {{- end }}
-          volumeMounts: {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- if .Values.webhooks.enabled }}
+            - --enable-webhooks=true
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.webhooks.enabled }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          {{- end }} 
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
           resources: {{- toYaml .Values.resources | nindent 12 }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "wave-fullname" .) }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+      {{- if .Values.webhooks.enabled }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ template "wave-fullname" . }}-webhook-server-cert
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
-      volumes: {{ toYaml .Values.extraVolumes | nindent 8 }}

--- a/charts/wave/templates/poddisruptionbudget.yaml
+++ b/charts/wave/templates/poddisruptionbudget.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{ include "wave.selectorLabels" . | nindent 6}}
+      {{ include "wave-labels.chart" . | nindent 6 }}
   maxUnavailable: 1
 {{- end }}

--- a/charts/wave/templates/webhook.yaml
+++ b/charts/wave/templates/webhook.yaml
@@ -1,0 +1,70 @@
+---
+{{- if .Values.webhooks.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: '{{ template "wave-fullname" . }}-mutating-webhook-configuration'
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "wave-fullname" . }}-serving-cert'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ template "wave-fullname" . }}-webhook-service'
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-apps-v1-deployment
+    failurePolicy: Ignore
+    name: deployments.wave.pusher.com
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ template "wave-fullname" . }}-webhook-service'
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-apps-v1-statefulset
+    failurePolicy: Ignore
+    name: statefulsets.wave.pusher.com
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - statefulsets
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ template "wave-fullname" . }}-webhook-service'
+        namespace: '{{ .Release.Namespace }}'
+        path: /mutate-apps-v1-daemonset
+    failurePolicy: Ignore
+    name: daemonsets.wave.pusher.com
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - daemonsets
+    sideEffects: NoneOnDryRun
+{{- end }}

--- a/charts/wave/templates/webhook_certificate.yaml
+++ b/charts/wave/templates/webhook_certificate.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.webhooks.enabled }}
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "wave-fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "wave-fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ template "wave-fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ template "wave-fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ template "wave-fullname" . }}-selfsigned-issuer
+  secretName: {{ template "wave-fullname" . }}-webhook-server-cert
+{{- end }}

--- a/charts/wave/templates/webhook_service.yaml
+++ b/charts/wave/templates/webhook_service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webhooks.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "wave-fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{ include "wave-labels.chart" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    {{ include "wave-labels.chart" . | nindent 4 }}
+{{- end }}

--- a/charts/wave/values.yaml
+++ b/charts/wave/values.yaml
@@ -47,6 +47,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+webhooks:
+  enabled: false
+
 # Period for reconciliation
 # syncPeriod: 5m
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-apps-v1-daemonset
+  failurePolicy: Ignore
+  name: daemonsets.wave.pusher.com
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-apps-v1-deployment
+  failurePolicy: Ignore
+  name: deployments.wave.pusher.com
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-apps-v1-statefulset
+  failurePolicy: Ignore
+  name: statefulsets.wave.pusher.com
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - statefulsets
+  sideEffects: NoneOnDryRun

--- a/hack/production.yaml
+++ b/hack/production.yaml
@@ -1,0 +1,16 @@
+# production setup used in tests
+replicas: 2
+
+webhooks:
+  enabled: true
+
+pdb:
+  enabled: true
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app: wave

--- a/pkg/controller/daemonset/daemonset_controller_suite_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_suite_test.go
@@ -31,6 +31,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var cfg *rest.Config
@@ -45,8 +48,51 @@ var t *envtest.Environment
 var testCtx, testCancel = context.WithCancel(context.Background())
 
 var _ = BeforeSuite(func() {
+	failurePolicy := admissionv1.Ignore
+	sideEffects := admissionv1.SideEffectClassNone
+	webhookPath := "/mutate-apps-v1-daemonset"
+	webhookInstallOptions := envtest.WebhookInstallOptions{
+		MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "daemonset-operator",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MutatingWebhookConfiguration",
+					APIVersion: "admissionregistration.k8s.io/v1",
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name:                    "daemonsets.wave.pusher.com",
+						AdmissionReviewVersions: []string{"v1"},
+						FailurePolicy:           &failurePolicy,
+						ClientConfig: admissionv1.WebhookClientConfig{
+							Service: &admissionv1.ServiceReference{
+								Path: &webhookPath,
+							},
+						},
+						Rules: []admissionv1.RuleWithOperations{
+							{
+								Operations: []admissionv1.OperationType{
+									admissionv1.Create,
+									admissionv1.Update,
+								},
+								Rule: admissionv1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"daemonsets"},
+								},
+							},
+						},
+						SideEffects: &sideEffects,
+					},
+				},
+			},
+		},
+	}
 	t = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		WebhookInstallOptions: webhookInstallOptions,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -453,7 +453,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 
 		It("Has scheduling disabled", func() {
 			m.Get(daemonset, timeout).Should(Succeed())
-			Expect(daemonset.Spec.Template.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(daemonset.Spec.Template.Spec.SchedulerName).To(Equal(core.SchedulingDisabledSchedulerName))
 			Expect(daemonset.ObjectMeta.Annotations[core.SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
 		})
 

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -445,7 +445,7 @@ var _ = Describe("DaemonSet controller Suite", func() {
 			annotations[core.RequiredAnnotation] = "true"
 			daemonset.SetAnnotations(annotations)
 
-			// Create a deployment and wait for it to be reconciled
+			// Create a daemonset and wait for it to be reconciled
 			clearReconciled()
 			m.Create(daemonset).Should(Succeed())
 			waitForDaemonSetReconciled(daemonset)

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	webhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var _ = Describe("DaemonSet controller Suite", func() {
@@ -94,6 +95,11 @@ var _ = Describe("DaemonSet controller Suite", func() {
 			Metrics: metricsserver.Options{
 				BindAddress: "0",
 			},
+			WebhookServer: webhook.NewServer(webhook.Options{
+				Host:    t.WebhookInstallOptions.LocalServingHost,
+				Port:    t.WebhookInstallOptions.LocalServingPort,
+				CertDir: t.WebhookInstallOptions.LocalServingCertDir,
+			}),
 		})
 		Expect(err).NotTo(HaveOccurred())
 		var cerr error
@@ -105,6 +111,10 @@ var _ = Describe("DaemonSet controller Suite", func() {
 		r := newReconciler(mgr)
 		recFn, requestsStart, requests = SetupTestReconcile(r)
 		Expect(add(mgr, recFn, r.handler)).NotTo(HaveOccurred())
+
+		// register mutating pod webhook
+		err = AddDaemonSetWebhook(mgr)
+		Expect(err).ToNot(HaveOccurred())
 
 		testCtx, testCancel = context.WithCancel(context.Background())
 		go Run(testCtx, mgr)
@@ -131,11 +141,6 @@ var _ = Describe("DaemonSet controller Suite", func() {
 		m.Get(s3, timeout).Should(Succeed())
 
 		daemonset = utils.ExampleDaemonSet.DeepCopy()
-
-		// Create a daemonset and wait for it to be reconciled
-		clearReconciled()
-		m.Create(daemonset).Should(Succeed())
-		waitForDaemonSetReconciled(daemonset)
 	})
 
 	AfterEach(func() {
@@ -149,7 +154,14 @@ var _ = Describe("DaemonSet controller Suite", func() {
 		)
 	})
 
-	Context("When a DaemonSet is reconciled", func() {
+	Context("When a DaemonSet with all children existing is reconciled", func() {
+		BeforeEach(func() {
+			// Create a daemonset and wait for it to be reconciled
+			clearReconciled()
+			m.Create(daemonset).Should(Succeed())
+			waitForDaemonSetReconciled(daemonset)
+		})
+
 		Context("And it has the required annotation", func() {
 			BeforeEach(func() {
 				addAnnotation := func(obj client.Object) client.Object {
@@ -163,12 +175,16 @@ var _ = Describe("DaemonSet controller Suite", func() {
 				}
 				clearReconciled()
 				m.Update(daemonset, addAnnotation).Should(Succeed())
-				// Two runs since we the controller retriggers itself by changing the object
-				waitForDaemonSetReconciled(daemonset)
 				waitForDaemonSetReconciled(daemonset)
 
 				// Get the updated DaemonSet
 				m.Get(daemonset, timeout).Should(Succeed())
+			})
+
+			It("Has scheduling enabled", func() {
+				m.Get(daemonset, timeout).Should(Succeed())
+				Expect(daemonset.Spec.Template.Spec.SchedulerName).To(Equal("default-scheduler"))
+				Expect(daemonset.ObjectMeta.Annotations).NotTo(HaveKey(core.SchedulingDisabledAnnotation))
 			})
 
 			It("Adds a config hash to the Pod Template", func() {
@@ -204,7 +220,6 @@ var _ = Describe("DaemonSet controller Suite", func() {
 					}
 					clearReconciled()
 					m.Update(daemonset, removeContainer2).Should(Succeed())
-					waitForDaemonSetReconciled(daemonset)
 					waitForDaemonSetReconciled(daemonset)
 
 					// Get the updated DaemonSet
@@ -419,4 +434,42 @@ var _ = Describe("DaemonSet controller Suite", func() {
 		})
 	})
 
+	Context("When a DaemonSet with missing children is reconciled", func() {
+		BeforeEach(func() {
+			m.Delete(cm1).Should(Succeed())
+
+			annotations := daemonset.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[core.RequiredAnnotation] = "true"
+			daemonset.SetAnnotations(annotations)
+
+			// Create a deployment and wait for it to be reconciled
+			clearReconciled()
+			m.Create(daemonset).Should(Succeed())
+			waitForDaemonSetReconciled(daemonset)
+		})
+
+		It("Has scheduling disabled", func() {
+			m.Get(daemonset, timeout).Should(Succeed())
+			Expect(daemonset.Spec.Template.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(daemonset.ObjectMeta.Annotations[core.SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
+		})
+
+		Context("And the missing child is created", func() {
+			BeforeEach(func() {
+				clearReconciled()
+				cm1 = utils.ExampleConfigMap1.DeepCopy()
+				m.Create(cm1).Should(Succeed())
+				waitForDaemonSetReconciled(daemonset)
+			})
+
+			It("Has scheduling renabled", func() {
+				m.Get(daemonset, timeout).Should(Succeed())
+				Expect(daemonset.Spec.Template.Spec.SchedulerName).To(Equal("default-scheduler"))
+				Expect(daemonset.ObjectMeta.Annotations).NotTo(HaveKey(core.SchedulingDisabledAnnotation))
+			})
+		})
+	})
 })

--- a/pkg/controller/daemonset/daemonset_webhook.go
+++ b/pkg/controller/daemonset/daemonset_webhook.go
@@ -1,0 +1,39 @@
+package daemonset
+
+import (
+	"context"
+
+	"github.com/wave-k8s/wave/pkg/core"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/mutate-apps-v1-daemonset,mutating=true,failurePolicy=ignore,groups=apps,resources=daemonsets,verbs=create;update,versions=v1,name=daemonsets.wave.pusher.com,admissionReviewVersions=v1,sideEffects=NoneOnDryRun
+
+type DaemonSetWebhook struct {
+	client.Client
+	Handler *core.Handler
+}
+
+func (a *DaemonSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	err = a.Handler.HandleDaemonSetWebhook(obj.(*appsv1.DaemonSet), request.DryRun, request.Operation == "CREATE")
+	return err
+}
+
+func AddDaemonSetWebhook(mgr manager.Manager) error {
+	err := builder.WebhookManagedBy(mgr).For(&appsv1.DaemonSet{}).WithDefaulter(
+		&DaemonSetWebhook{
+			Client:  mgr.GetClient(),
+			Handler: core.NewHandler(mgr.GetClient(), mgr.GetEventRecorderFor("wave")),
+		}).Complete()
+
+	return err
+}

--- a/pkg/controller/deployment/deployment_controller_suite_test.go
+++ b/pkg/controller/deployment/deployment_controller_suite_test.go
@@ -33,6 +33,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var cfg *rest.Config
@@ -47,8 +50,51 @@ var t *envtest.Environment
 var testCtx, testCancel = context.WithCancel(context.Background())
 
 var _ = BeforeSuite(func() {
+	failurePolicy := admissionv1.Ignore
+	sideEffects := admissionv1.SideEffectClassNone
+	webhookPath := "/mutate-apps-v1-deployment"
+	webhookInstallOptions := envtest.WebhookInstallOptions{
+		MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment-operator",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MutatingWebhookConfiguration",
+					APIVersion: "admissionregistration.k8s.io/v1",
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name:                    "deployments.wave.pusher.com",
+						AdmissionReviewVersions: []string{"v1"},
+						FailurePolicy:           &failurePolicy,
+						ClientConfig: admissionv1.WebhookClientConfig{
+							Service: &admissionv1.ServiceReference{
+								Path: &webhookPath,
+							},
+						},
+						Rules: []admissionv1.RuleWithOperations{
+							{
+								Operations: []admissionv1.OperationType{
+									admissionv1.Create,
+									admissionv1.Update,
+								},
+								Rule: admissionv1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"deployments"},
+								},
+							},
+						},
+						SideEffects: &sideEffects,
+					},
+				},
+			},
+		},
+	}
 	t = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		WebhookInstallOptions: webhookInstallOptions,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}
 	apis.AddToScheme(scheme.Scheme)
 

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	webhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var _ = Describe("Deployment controller Suite", func() {
@@ -101,6 +102,11 @@ var _ = Describe("Deployment controller Suite", func() {
 			Metrics: metricsserver.Options{
 				BindAddress: "0",
 			},
+			WebhookServer: webhook.NewServer(webhook.Options{
+				Host:    t.WebhookInstallOptions.LocalServingHost,
+				Port:    t.WebhookInstallOptions.LocalServingPort,
+				CertDir: t.WebhookInstallOptions.LocalServingCertDir,
+			}),
 		})
 		Expect(err).NotTo(HaveOccurred())
 		var cerr error
@@ -112,6 +118,10 @@ var _ = Describe("Deployment controller Suite", func() {
 		r := newReconciler(mgr)
 		recFn, requestsStart, requests = SetupTestReconcile(r)
 		Expect(add(mgr, recFn, r.handler)).NotTo(HaveOccurred())
+
+		// register mutating pod webhook
+		err = AddDeploymentWebhook(mgr)
+		Expect(err).ToNot(HaveOccurred())
 
 		testCtx, testCancel = context.WithCancel(context.Background())
 		go Run(testCtx, mgr)
@@ -156,11 +166,6 @@ var _ = Describe("Deployment controller Suite", func() {
 		m.Get(s6, timeout).Should(Succeed())
 
 		deployment = utils.ExampleDeployment.DeepCopy()
-
-		// Create a deployment and wait for it to be reconciled
-		clearReconciled()
-		m.Create(deployment).Should(Succeed())
-		waitForDeploymentReconciled(deployment)
 	})
 
 	AfterEach(func() {
@@ -174,7 +179,14 @@ var _ = Describe("Deployment controller Suite", func() {
 		)
 	})
 
-	Context("When a Deployment is reconciled", func() {
+	Context("When a Deployment with all children existing is reconciled", func() {
+		BeforeEach(func() {
+			// Create a deployment and wait for it to be reconciled
+			clearReconciled()
+			m.Create(deployment).Should(Succeed())
+			waitForDeploymentReconciled(deployment)
+		})
+
 		Context("And it has the required annotation", func() {
 			BeforeEach(func() {
 				addAnnotation := func(obj client.Object) client.Object {
@@ -188,12 +200,16 @@ var _ = Describe("Deployment controller Suite", func() {
 				}
 				clearReconciled()
 				m.Update(deployment, addAnnotation).Should(Succeed())
-				// Two runs since we the controller retriggers itself by changing the object
-				waitForDeploymentReconciled(deployment)
 				waitForDeploymentReconciled(deployment)
 
 				// Get the updated Deployment
 				m.Get(deployment, timeout).Should(Succeed())
+			})
+
+			It("Has scheduling enabled", func() {
+				m.Get(deployment, timeout).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal("default-scheduler"))
+				Expect(deployment.ObjectMeta.Annotations).NotTo(HaveKey(core.SchedulingDisabledAnnotation))
 			})
 
 			It("Adds a config hash to the Pod Template", func() {
@@ -231,7 +247,6 @@ var _ = Describe("Deployment controller Suite", func() {
 					}
 					clearReconciled()
 					m.Update(deployment, removeContainer2).Should(Succeed())
-					waitForDeploymentReconciled(deployment)
 					waitForDeploymentReconciled(deployment)
 
 					// Get the updated Deployment
@@ -441,6 +456,45 @@ var _ = Describe("Deployment controller Suite", func() {
 
 				m.Update(cm1, modifyCM).Should(Succeed())
 				consistentlyDeploymentNotReconciled(deployment)
+			})
+		})
+	})
+
+	Context("When a Deployment with missing children is reconciled", func() {
+		BeforeEach(func() {
+			m.Delete(cm1).Should(Succeed())
+
+			annotations := deployment.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[core.RequiredAnnotation] = "true"
+			deployment.SetAnnotations(annotations)
+
+			// Create a deployment and wait for it to be reconciled
+			clearReconciled()
+			m.Create(deployment).Should(Succeed())
+			waitForDeploymentReconciled(deployment)
+		})
+
+		It("Has scheduling disabled", func() {
+			m.Get(deployment, timeout).Should(Succeed())
+			Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(deployment.ObjectMeta.Annotations[core.SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
+		})
+
+		Context("And the missing child is created", func() {
+			BeforeEach(func() {
+				clearReconciled()
+				cm1 = utils.ExampleConfigMap1.DeepCopy()
+				m.Create(cm1).Should(Succeed())
+				waitForDeploymentReconciled(deployment)
+			})
+
+			It("Has scheduling renabled", func() {
+				m.Get(deployment, timeout).Should(Succeed())
+				Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal("default-scheduler"))
+				Expect(deployment.ObjectMeta.Annotations).NotTo(HaveKey(core.SchedulingDisabledAnnotation))
 			})
 		})
 	})

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -479,7 +479,7 @@ var _ = Describe("Deployment controller Suite", func() {
 
 		It("Has scheduling disabled", func() {
 			m.Get(deployment, timeout).Should(Succeed())
-			Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal(core.SchedulingDisabledSchedulerName))
 			Expect(deployment.ObjectMeta.Annotations[core.SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
 		})
 

--- a/pkg/controller/deployment/deployment_webhook.go
+++ b/pkg/controller/deployment/deployment_webhook.go
@@ -1,0 +1,39 @@
+package deployment
+
+import (
+	"context"
+
+	"github.com/wave-k8s/wave/pkg/core"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/mutate-apps-v1-deployment,mutating=true,failurePolicy=ignore,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=deployments.wave.pusher.com,admissionReviewVersions=v1,sideEffects=NoneOnDryRun
+
+type DeploymentWebhook struct {
+	client.Client
+	Handler *core.Handler
+}
+
+func (a *DeploymentWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	err = a.Handler.HandleDeploymentWebhook(obj.(*appsv1.Deployment), request.DryRun, request.Operation == "CREATE")
+	return err
+}
+
+func AddDeploymentWebhook(mgr manager.Manager) error {
+	err := builder.WebhookManagedBy(mgr).For(&appsv1.Deployment{}).WithDefaulter(
+		&DeploymentWebhook{
+			Client:  mgr.GetClient(),
+			Handler: core.NewHandler(mgr.GetClient(), mgr.GetEventRecorderFor("wave")),
+		}).Complete()
+
+	return err
+}

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -449,7 +449,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 			annotations[core.RequiredAnnotation] = "true"
 			statefulset.SetAnnotations(annotations)
 
-			// Create a deployment and wait for it to be reconciled
+			// Create a statefulset and wait for it to be reconciled
 			clearReconciled()
 			m.Create(statefulset).Should(Succeed())
 			waitForStatefulSetReconciled(statefulset)

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -457,7 +457,7 @@ var _ = Describe("StatefulSet controller Suite", func() {
 
 		It("Has scheduling disabled", func() {
 			m.Get(statefulset, timeout).Should(Succeed())
-			Expect(statefulset.Spec.Template.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(statefulset.Spec.Template.Spec.SchedulerName).To(Equal(core.SchedulingDisabledSchedulerName))
 			Expect(statefulset.ObjectMeta.Annotations[core.SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
 		})
 

--- a/pkg/controller/statefulset/statefulset_webhook.go
+++ b/pkg/controller/statefulset/statefulset_webhook.go
@@ -1,0 +1,39 @@
+package statefulset
+
+import (
+	"context"
+
+	"github.com/wave-k8s/wave/pkg/core"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/mutate-apps-v1-statefulset,mutating=true,failurePolicy=ignore,groups=apps,resources=statefulsets,verbs=create;update,versions=v1,name=statefulsets.wave.pusher.com,admissionReviewVersions=v1,sideEffects=NoneOnDryRun
+
+type StatefulSetWebhook struct {
+	client.Client
+	Handler *core.Handler
+}
+
+func (a *StatefulSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	err = a.Handler.HandleStatefulSetWebhook(obj.(*appsv1.StatefulSet), request.DryRun, request.Operation == "CREATE")
+	return err
+}
+
+func AddStatefulSetWebhook(mgr manager.Manager) error {
+	err := builder.WebhookManagedBy(mgr).For(&appsv1.StatefulSet{}).WithDefaulter(
+		&StatefulSetWebhook{
+			Client:  mgr.GetClient(),
+			Handler: core.NewHandler(mgr.GetClient(), mgr.GetEventRecorderFor("wave")),
+		}).Complete()
+
+	return err
+}

--- a/pkg/core/hash.go
+++ b/pkg/core/hash.go
@@ -105,7 +105,7 @@ func getSecretData(child configObject) map[string][]byte {
 	return keyData
 }
 
-// setConfigHash upates the configuration hash of the given Deployment to the
+// setConfigHash updates the configuration hash of the given Deployment to the
 // given string
 func setConfigHash(obj podController, hash string) {
 	// Get the existing annotations
@@ -119,4 +119,10 @@ func setConfigHash(obj podController, hash string) {
 	annotations[ConfigHashAnnotation] = hash
 	podTemplate.SetAnnotations(annotations)
 	obj.SetPodTemplate(podTemplate)
+}
+
+// getConfigHash return the config hash string
+func getConfigHash(obj podController) string {
+	podTemplate := obj.GetPodTemplate()
+	return podTemplate.GetAnnotations()[ConfigHashAnnotation]
 }

--- a/pkg/core/scheduler.go
+++ b/pkg/core/scheduler.go
@@ -1,0 +1,56 @@
+package core
+
+// disableScheduling sets an invalid scheduler and adds an annotation with the original scheduler
+func disableScheduling(obj podController) {
+	if isSchedulingDisabled(obj) {
+		return
+	}
+
+	// Get the existing annotations
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Store previous scheduler in annotation
+	schedulerName := obj.GetPodTemplate().Spec.SchedulerName
+	annotations[SchedulingDisabledAnnotation] = schedulerName
+	obj.SetAnnotations(annotations)
+
+	// Set invalid scheduler
+	podTemplate := obj.GetPodTemplate()
+	podTemplate.Spec.SchedulerName = "invalid"
+	obj.SetPodTemplate(podTemplate)
+}
+
+// isSchedulingDisabled returns true if scheduling has been disabled by wave
+func isSchedulingDisabled(obj podController) bool {
+	// Get the existing annotations
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[SchedulingDisabledAnnotation]
+	return ok
+}
+
+// enableScheduling restore scheduling if it has been disabled by wave
+func restoreScheduling(obj podController) {
+	// Get the existing annotations
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	schedulerName, ok := annotations[SchedulingDisabledAnnotation]
+	if !ok {
+		// Scheduling has not been disabled
+		return
+	}
+	delete(annotations, SchedulingDisabledAnnotation)
+	obj.SetAnnotations(annotations)
+
+	// Restore scheduler
+	podTemplate := obj.GetPodTemplate()
+	podTemplate.Spec.SchedulerName = schedulerName
+	obj.SetPodTemplate(podTemplate)
+}

--- a/pkg/core/scheduler.go
+++ b/pkg/core/scheduler.go
@@ -19,7 +19,7 @@ func disableScheduling(obj podController) {
 
 	// Set invalid scheduler
 	podTemplate := obj.GetPodTemplate()
-	podTemplate.Spec.SchedulerName = "invalid"
+	podTemplate.Spec.SchedulerName = SchedulingDisabledSchedulerName
 	obj.SetPodTemplate(podTemplate)
 }
 

--- a/pkg/core/scheduler_test.go
+++ b/pkg/core/scheduler_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 Pusher Ltd. and Wave Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/wave-k8s/wave/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+var _ = Describe("Wave scheduler Suite", func() {
+	var deploymentObject *appsv1.Deployment
+	var podControllerDeployment podController
+
+	BeforeEach(func() {
+		deploymentObject = utils.ExampleDeployment.DeepCopy()
+		podControllerDeployment = &deployment{deploymentObject}
+	})
+
+	Context("When scheduler is disabled", func() {
+		BeforeEach(func() {
+			disableScheduling(podControllerDeployment)
+		})
+
+		It("Sets the annotations and stores the previous scheduler", func() {
+			annotations := podControllerDeployment.GetAnnotations()
+			Expect(annotations[SchedulingDisabledAnnotation]).To(Equal("default-scheduler"))
+		})
+
+		It("Disables scheduling", func() {
+			podTemplate := podControllerDeployment.GetPodTemplate()
+			Expect(podTemplate.Spec.SchedulerName).To(Equal("invalid"))
+		})
+
+		It("Is reports as disabled", func() {
+			Expect(isSchedulingDisabled(podControllerDeployment)).To(BeTrue())
+		})
+
+		Context("And Is Restored", func() {
+			BeforeEach(func() {
+				restoreScheduling(podControllerDeployment)
+			})
+
+			It("Removes the annotations", func() {
+				annotations := podControllerDeployment.GetAnnotations()
+				Expect(annotations).NotTo(HaveKey(SchedulingDisabledAnnotation))
+			})
+
+			It("Restores the scheduler", func() {
+				podTemplate := podControllerDeployment.GetPodTemplate()
+				Expect(podTemplate.Spec.SchedulerName).To(Equal("default-scheduler"))
+			})
+
+			It("Is does not report as disabled", func() {
+				Expect(isSchedulingDisabled(podControllerDeployment)).To(BeFalse())
+			})
+
+		})
+
+	})
+})

--- a/pkg/core/scheduler_test.go
+++ b/pkg/core/scheduler_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Wave scheduler Suite", func() {
 
 		It("Disables scheduling", func() {
 			podTemplate := podControllerDeployment.GetPodTemplate()
-			Expect(podTemplate.Spec.SchedulerName).To(Equal("invalid"))
+			Expect(podTemplate.Spec.SchedulerName).To(Equal(SchedulingDisabledSchedulerName))
 		})
 
 		It("Is reports as disabled", func() {

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -21,6 +21,9 @@ const (
 	// due to missing children and contains the original scheduler
 	SchedulingDisabledAnnotation = "wave.pusher.com/scheduling-disabled"
 
+	// SchedulingDisabledSchedulerName is the dummy scheduler to disable scheduling of pods
+	SchedulingDisabledSchedulerName = "wave.pusher.com/invalid"
+
 	// RequiredAnnotation is the key of the annotation on the Deployment that Wave
 	// checks for before processing the deployment
 	RequiredAnnotation = "wave.pusher.com/update-on-config-change"

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,6 +16,10 @@ const (
 	// FinalizerString is the finalizer added to deployments to allow Wave to
 	// perform advanced deletion logic
 	FinalizerString = "wave.pusher.com/finalizer"
+
+	// SchedulingDisabledAnnotation is set on a deployment if scheduling has been disabled
+	// due to missing children and contains the original scheduler
+	SchedulingDisabledAnnotation = "wave.pusher.com/scheduling-disabled"
 
 	// RequiredAnnotation is the key of the annotation on the Deployment that Wave
 	// checks for before processing the deployment
@@ -123,5 +128,24 @@ func (d *daemonset) GetApiObject() client.Object {
 		Status:     d.Status,
 		Spec:       d.Spec,
 		ObjectMeta: d.ObjectMeta,
+	}
+}
+
+func GetNamespacedName(name string, namespace string) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+type ObjectWithNameAndNamespace interface {
+	GetNamespace() string
+	GetName() string
+}
+
+func GetNamespacedNameFromObject(obj ObjectWithNameAndNamespace) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}
 }

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -44,6 +44,7 @@ var ExampleDeployment = &appsv1.Deployment{
 				Labels: labels,
 			},
 			Spec: corev1.PodSpec{
+				SchedulerName: "default-scheduler",
 				Volumes: []corev1.Volume{
 					{
 						Name: "secret1",


### PR DESCRIPTION
Implement (optional) mutating webhooks to reduce the number or restarts in new deployments when configmaps and secrets already exist.

Additional changes (based on observations during testing):

- fix non-404 error handle when loading children
- fix RBACs
- test minimal and typical production setup
- fixed reconcile loop when secrets/configmaps are missing. previously (even before my refactoring) wave would retry this with exponential-backoff
- watch not (yet) existing secrets/configmaps for much faster updates when they are created. with the new watcher mechanism we do not rely on ownerReference and can watch for secrets/configmaps before they exist. this allows much faster reconciles (and allows us the get rid of polling; see previous point)
- allow watching secrets/configmaps in other namespaces
- when using webhooks: disable scheduling when secrets/configmaps are missing; reenable scheduling once secrets/configmaps; this prevents unneccessary container restarts.
  - technically, we patch the deployment to use an invalid scheduler; this will result in a Pending pod (instead of ContainerCreating which will eventually timeout); we store the original scheduler in an annotation and later reverse this
  - this allows to install helm releases and not have pods restart 2-3 times due to wave
 
Everything is tested. Let me know if you want any changes.

On top of #154.