### PR TITLE
Add lock to watcher hash map to prevent concurrent access panics

### DIFF
--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -189,12 +189,12 @@ var _ = Describe("Wave controller Suite", func() {
 			})
 
 			It("Is watched by the handler", func() {
-				Expect(h.GetWatchedConfigmaps()[example1Name]).To(HaveKey(instanceName))
-				Expect(h.GetWatchedConfigmaps()[example2Name]).To(HaveKey(instanceName))
-				Expect(h.GetWatchedConfigmaps()[example3Name]).To(HaveKey(instanceName))
-				Expect(h.GetWatchedSecrets()[example1Name]).To(HaveKey(instanceName))
-				Expect(h.GetWatchedSecrets()[example2Name]).To(HaveKey(instanceName))
-				Expect(h.GetWatchedSecrets()[example3Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedConfigmaps().watchers[example1Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedConfigmaps().watchers[example2Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedConfigmaps().watchers[example3Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedSecrets().watchers[example1Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedSecrets().watchers[example2Name]).To(HaveKey(instanceName))
+				Expect(h.GetWatchedSecrets().watchers[example3Name]).To(HaveKey(instanceName))
 			})
 
 			It("Sends an event when updating the hash", func() {
@@ -240,12 +240,12 @@ var _ = Describe("Wave controller Suite", func() {
 				})
 
 				It("Is is not longer watched by the handler", func() {
-					Expect(h.GetWatchedConfigmaps()[example1Name]).To(HaveKey(instanceName))
-					Expect(h.GetWatchedConfigmaps()[example2Name]).NotTo(HaveKey(instanceName))
-					Expect(h.GetWatchedConfigmaps()[example3Name]).To(HaveKey(instanceName))
-					Expect(h.GetWatchedSecrets()[example1Name]).To(HaveKey(instanceName))
-					Expect(h.GetWatchedSecrets()[example2Name]).NotTo(HaveKey(instanceName))
-					Expect(h.GetWatchedSecrets()[example3Name]).To(HaveKey(instanceName))
+					Expect(h.GetWatchedConfigmaps().watchers[example1Name]).To(HaveKey(instanceName))
+					Expect(h.GetWatchedConfigmaps().watchers[example2Name]).NotTo(HaveKey(instanceName))
+					Expect(h.GetWatchedConfigmaps().watchers[example3Name]).To(HaveKey(instanceName))
+					Expect(h.GetWatchedSecrets().watchers[example1Name]).To(HaveKey(instanceName))
+					Expect(h.GetWatchedSecrets().watchers[example2Name]).NotTo(HaveKey(instanceName))
+					Expect(h.GetWatchedSecrets().watchers[example3Name]).To(HaveKey(instanceName))
 				})
 			})
 
@@ -464,8 +464,8 @@ var _ = Describe("Wave controller Suite", func() {
 				})
 
 				It("No longer is watched by the handler", func() {
-					Expect(len(h.GetWatchedConfigmaps())).To(Equal(0))
-					Expect(len(h.GetWatchedSecrets())).To(Equal(0))
+					Expect(len(h.GetWatchedConfigmaps().watchers)).To(Equal(0))
+					Expect(len(h.GetWatchedSecrets().watchers)).To(Equal(0))
 				})
 			})
 
@@ -486,8 +486,8 @@ var _ = Describe("Wave controller Suite", func() {
 				})
 
 				It("No longer is watched by the handler", func() {
-					Expect(len(h.GetWatchedConfigmaps())).To(Equal(0))
-					Expect(len(h.GetWatchedSecrets())).To(Equal(0))
+					Expect(len(h.GetWatchedConfigmaps().watchers)).To(Equal(0))
+					Expect(len(h.GetWatchedSecrets().watchers)).To(Equal(0))
 				})
 			})
 		})
@@ -499,8 +499,8 @@ var _ = Describe("Wave controller Suite", func() {
 			})
 
 			It("Is not watched by the handler", func() {
-				Expect(len(h.GetWatchedConfigmaps())).To(Equal(0))
-				Expect(len(h.GetWatchedSecrets())).To(Equal(0))
+				Expect(len(h.GetWatchedConfigmaps().watchers)).To(Equal(0))
+				Expect(len(h.GetWatchedSecrets().watchers)).To(Equal(0))
 			})
 
 			It("Doesn't add a config hash to the Pod Template", func() {


### PR DESCRIPTION
I rolled out Wave 0.7 to a cluster with about 1k deployments. Migation went smooth. However, it crashed due to a concurrent access to the new watcher hashmap. Apparently, watchers are separate goroutines and run concurrently:

```
fatal error: concurrent map read and map write

goroutine 199 [running]:
github.com/wave-k8s/wave/pkg/core.(*enqueueRequestForWatcher).queueOwnerReconcileRequest(0xc00049c3e8, {0x1b49930?, 0xc00f2c5b80?}, {0x1b3ff10, 0xc000498160})
```
I fixed that by adding mutexes. Obviously, access to this hashmap can be optimized further.

However, even with this crash it performs well. Restarts are fast enough and the other controller will take over within a few seconds. Even though it crashes occasionally the overall CPU load is lower than before:

<img width="741" alt="grafik" src="https://github.com/wave-k8s/wave/assets/557540/740ad12a-9d58-4461-8714-da6cb477f1fc">

Same appears to be the case for memory usage:

<img width="741" alt="grafik" src="https://github.com/wave-k8s/wave/assets/557540/3e281280-218c-48c5-82a6-9ae17a28d344">

Upgrade happened around 21:00 which explains the small CPU spike during that time.