### PR TITLE
Reduce informer sync interval to default 10h

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rather than when the Pods happen to be re-cycled.
 
 ## Compatibility
 
-Wave uses the the golang Kubernetes client library which only supports
+Wave uses the golang Kubernetes client library which only supports
 the previous and the next Kubernetes version.
 However, since Wave only edits Deployments, Daemonsets and StatefulSet
 we can support older Kubernetes verions as long as no fields were removed
@@ -162,13 +162,21 @@ the Kubernetes API server. Every informer has a sync period, after which it will
 refresh all resources within its cache. At this point, every item in the cache
 is queued for reconciliation by the controller.
 
-Therefore, by setting the following flag;
+By default, sync will happen every 10h.
+Kubernetes will inform Wave about changes in any Deployment, DaemonSet,
+StatefulSet, Secret or ConfigMap in the meantime and Wave will trigger a
+reconciliation right away.
+If you encounter any bugs you can reduce sync period by setting the following flag:
 
 ```
---sync-period=5m // Default value of 5m (5 minutes)
+--sync-period=5m // Default value of 10h (10 hours)
 ```
 
-You can ensure that every resource will be reconciled at least every 5 minutes.
+This will ensure that every resource will be reconciled at least every 5 minutes.
+Please note that this will cause more load on your API and increase CPU load in
+the Wave container.
+It might also increase latency during the time of the sync.
+Do not set this unless you encounter bugs (and in that case please tell us).
 
 ## Quick Start
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,7 +44,7 @@ var (
 	leaderElection          = flag.Bool("leader-election", false, "Should the controller use leader election")
 	leaderElectionID        = flag.String("leader-election-id", "", "Name of the configmap used by the leader election system")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace for the configmap used by the leader election system")
-	syncPeriod              = flag.Duration("sync-period", 5*time.Minute, "Reconcile sync period")
+	syncPeriod              = flag.Duration("sync-period", 10*time.Hour, "Reconcile sync period")
 	showVersion             = flag.Bool("version", false, "Show version and exit")
 	enableWebhooks          = flag.Bool("enable-webhooks", false, "Enable webhooks")
 	setupLog                = ctrl.Log.WithName("setup")


### PR DESCRIPTION
Wave sets a default informer sync interval of 5m. Prior to 0.7 this has been needed to catch changes in configmaps/secrets which were created after the deployment. We actually used `1m` before which cause a lot of stress on the API server.

Luckily, this is no longer needed. I reduced it to the controller default of 10h. 
Guess this issue comment explains it well: https://github.com/kubernetes-sigs/controller-runtime/issues/521#issuecomment-518457302. Since we do not need any periodoc reconcile (anymore) we should reduce it accordingly.

I updated the README to make clear that you probably should not change this unless you run into bugs with stale resources.