### PR TITLE
allow to only watch certain namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ the Wave container.
 It might also increase latency during the time of the sync.
 Do not set this unless you encounter bugs (and in that case please tell us).
 
+#### Limit Namespaces
+
+You can limit Wave to only watch certain namespaces:
+
+```
+--namespaces=your-namespace,other-namespace
+```
+
 ## Quick Start
 
 If you haven't yet got Wave running on your cluster, see

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/wave-k8s/wave/pkg/apis"
+	"github.com/wave-k8s/wave/pkg/core"
+
 	"github.com/wave-k8s/wave/pkg/controller"
 	"github.com/wave-k8s/wave/pkg/controller/daemonset"
 	"github.com/wave-k8s/wave/pkg/controller/deployment"
@@ -47,6 +49,7 @@ var (
 	syncPeriod              = flag.Duration("sync-period", 10*time.Hour, "Reconcile sync period")
 	showVersion             = flag.Bool("version", false, "Show version and exit")
 	enableWebhooks          = flag.Bool("enable-webhooks", false, "Enable webhooks")
+	namespaces              = flag.String("namespaces", "", "Comma-separated list of namespaces to watch. Defaults to all namespaces.")
 	setupLog                = ctrl.Log.WithName("setup")
 )
 
@@ -86,7 +89,8 @@ func main() {
 		LeaderElectionID:        *leaderElectionID,
 		LeaderElectionNamespace: *leaderElectionNamespace,
 		Cache: cache.Options{
-			SyncPeriod: syncPeriod,
+			SyncPeriod:        syncPeriod,
+			DefaultNamespaces: core.BuildCacheDefaultNamespaces(*namespaces),
 		},
 	})
 	if err != nil {

--- a/pkg/controller/daemonset/daemonset_controller_test.go
+++ b/pkg/controller/daemonset/daemonset_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -100,6 +101,9 @@ var _ = Describe("DaemonSet controller Suite", func() {
 				Port:    t.WebhookInstallOptions.LocalServingPort,
 				CertDir: t.WebhookInstallOptions.LocalServingCertDir,
 			}),
+			Cache: cache.Options{
+				DefaultNamespaces: core.BuildCacheDefaultNamespaces(""),
+			},
 		})
 		Expect(err).NotTo(HaveOccurred())
 		var cerr error

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -107,6 +108,9 @@ var _ = Describe("Deployment controller Suite", func() {
 				Port:    t.WebhookInstallOptions.LocalServingPort,
 				CertDir: t.WebhookInstallOptions.LocalServingCertDir,
 			}),
+			Cache: cache.Options{
+				DefaultNamespaces: core.BuildCacheDefaultNamespaces(""),
+			},
 		})
 		Expect(err).NotTo(HaveOccurred())
 		var cerr error

--- a/pkg/controller/statefulset/statefulset_controller_test.go
+++ b/pkg/controller/statefulset/statefulset_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -101,6 +102,9 @@ var _ = Describe("StatefulSet controller Suite", func() {
 				Port:    t.WebhookInstallOptions.LocalServingPort,
 				CertDir: t.WebhookInstallOptions.LocalServingCertDir,
 			}),
+			Cache: cache.Options{
+				DefaultNamespaces: core.BuildCacheDefaultNamespaces(""),
+			},
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/core/namespaces.go
+++ b/pkg/core/namespaces.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 Pusher Ltd. and Wave Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// BuildCacheDefaultNamespaces builds a cache config to watch namespaces
+func BuildCacheDefaultNamespaces(namespaces string) map[string]cache.Config {
+	if namespaces == "" {
+		// Default: All namespaces
+		return nil
+	}
+	defaultNamespaces := make(map[string]cache.Config)
+	for _, namespace := range strings.Split(namespaces, ",") {
+		defaultNamespaces[namespace] = cache.Config{}
+	}
+	return defaultNamespaces
+}

--- a/pkg/core/namespaces_test.go
+++ b/pkg/core/namespaces_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 Pusher Ltd. and Wave Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+var _ = Describe("Wave Namespace Suite", func() {
+	Context("BuildCacheDefaultNamespaces", func() {
+		It("Returns an empty config for an empty string", func() {
+			Expect(BuildCacheDefaultNamespaces("")).To(Equal(map[string]cache.Config(nil)))
+		})
+
+		It("Returns a single entry for one namespace", func() {
+			Expect(BuildCacheDefaultNamespaces("test")).To(Equal(map[string]cache.Config{
+				"test": {},
+			}))
+		})
+
+		It("Returns a multiple entries for a list of namespaces", func() {
+			Expect(BuildCacheDefaultNamespaces("test,ns1,ns2")).To(Equal(map[string]cache.Config{
+				"test": {},
+				"ns1":  {},
+				"ns2":  {},
+			}))
+		})
+	})
+})


### PR DESCRIPTION
Fix #37. Superseeds #92.

I tried writing a proper test for this but failed. I can change one of the controller tests to use the correct namespace and they will pass. However, I failed to do both (a) watch all namespaces and (b) for a separate test watch only some namespaces.