### PR TITLE
add predicate to only trigger on spec or annotation changes

### DIFF
--- a/pkg/controller/daemonset/daemonset_controller.go
+++ b/pkg/controller/daemonset/daemonset_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -59,7 +60,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, h *core.Handler) error {
 		return err
 	}
 
-	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.DaemonSet{}), &handler.EnqueueRequestForObject{})
+	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.DaemonSet{}), &handler.EnqueueRequestForObject{}, predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -60,7 +61,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, h *core.Handler) error {
 	}
 
 	// Watch for changes to Deployment
-	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.Deployment{}), &handler.EnqueueRequestForObject{})
+	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.Deployment{}), &handler.EnqueueRequestForObject{}, predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/statefulset/statefulset_controller.go
+++ b/pkg/controller/statefulset/statefulset_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -60,7 +61,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, h *core.Handler) error {
 	}
 
 	// Watch for changes to StatefulSet
-	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.StatefulSet{}), &handler.EnqueueRequestForObject{})
+	err = c.Watch(source.Kind(mgr.GetCache(), &appsv1.StatefulSet{}), &handler.EnqueueRequestForObject{}, predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On our clusters (1k Deployments, 5k Secrets) wave does not use significant CPU (about 10m) or memory (250MB). However, it causes API requests (not excessive but still more than 0) and we try to minimize that to keep kube-apiserver and etcd responsive.

The best way to improve performance it so do less. Previously, wave would trigger on changes in the status resource of Deployments, StatefulSets and DaemonSets. Those changes obviously are not interesting at all for wave and only cause noop reconciles.

This change will change the watch to only trigger a reconcile when annotations change or the spec changes.