### PR TITLE
Better children tracking

### DIFF
--- a/pkg/core/children.go
+++ b/pkg/core/children.go
@@ -276,6 +276,8 @@ func (h *Handler[I]) getObject(objectName types.NamespacedName, metadata configM
 
 // getExistingChildren returns a list of all Secrets and ConfigMaps that are
 // owned by the Deployment instance
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func (h *Handler[I]) getExistingChildren(obj I) ([]Object, error) {
 	inNamespace := client.InNamespace(obj.GetNamespace())
 
@@ -312,6 +314,8 @@ func (h *Handler[I]) getExistingChildren(obj I) ([]Object, error) {
 
 // isOwnedBy returns true if the child has an owner reference that points to
 // the owner object
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func isOwnedBy(child, owner metav1.Object) bool {
 	for _, ref := range child.GetOwnerReferences() {
 		if ref.UID == owner.GetUID() {

--- a/pkg/core/children.go
+++ b/pkg/core/children.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,156 +29,136 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// configMetadata contains information about ConfigMaps/Secrets referenced
-// within PodTemplates
-//
-// maps of configMetadata are return from the getChildNamesByType method
-// configMetadata is also used to pass info through the getObject methods
-type configMetadata struct {
-	required bool
-	allKeys  bool
-	keys     map[string]struct{}
-}
-
-type configMetadataMap map[types.NamespacedName]configMetadata
-
-type NotFoundError struct {
-	string
-}
-
-func (e *NotFoundError) Error() string {
-	return e.string
-}
-
 // getResult is returned from the getObject method as a helper struct to be
 // passed into a channel
 type getResult struct {
-	err      error
-	notFound bool
-	obj      Object
-	metadata configMetadata
+	Object
+	types.NamespacedName
+	error
 }
 
 // getCurrentChildren returns a list of all Secrets and ConfigMaps that are
 // referenced in the Deployment's spec.  Any reference to a whole ConfigMap or Secret
 // (i.e. via an EnvFrom or a Volume) will result in one entry in the list, irrespective of
 // whether individual elements are also references (i.e. via an Env entry).
-func (h *Handler[I]) getCurrentChildren(configMaps configMetadataMap, secrets configMetadataMap) ([]configObject, error) {
+func (h *Handler[I]) getCurrentChildren(configMapsConfig configMetadataList, secretsConfig configMetadataList) (map[types.NamespacedName]*corev1.ConfigMap, map[types.NamespacedName]*corev1.Secret, error) {
+	uniqueConfigMaps := make(map[types.NamespacedName]bool)
+	uniqueSecrets := make(map[types.NamespacedName]bool)
+
+	for _, cm := range configMapsConfig {
+		uniqueConfigMaps[cm.name] = true
+	}
+	for _, s := range secretsConfig {
+		uniqueSecrets[s.name] = true
+	}
+
 	// get all of ConfigMaps and Secrets
 	resultsChan := make(chan getResult)
-	for name, metadata := range configMaps {
-		go func(name types.NamespacedName, metadata configMetadata) {
-			resultsChan <- h.getConfigMap(name, metadata)
-		}(name, metadata)
+	for cm := range uniqueConfigMaps {
+		go func(name types.NamespacedName) {
+			resultsChan <- h.getConfigMap(name)
+		}(cm)
 	}
-	for name, metadata := range secrets {
-		go func(name types.NamespacedName, metadata configMetadata) {
-			resultsChan <- h.getSecret(name, metadata)
-		}(name, metadata)
+	for s := range uniqueSecrets {
+		go func(name types.NamespacedName) {
+			resultsChan <- h.getSecret(name)
+		}(s)
 	}
 
 	// Range over and collect results from the gets
 	var errs []string
-	var notFoundErrs []string
-	var children []configObject
-	for i := 0; i < len(configMaps)+len(secrets); i++ {
+	secrets := make(map[types.NamespacedName]*corev1.Secret)
+	configMaps := make(map[types.NamespacedName]*corev1.ConfigMap)
+	for i := 0; i < len(uniqueConfigMaps)+len(uniqueSecrets); i++ {
 		result := <-resultsChan
-		if result.err != nil {
-			if result.notFound {
-				notFoundErrs = append(notFoundErrs, result.err.Error())
-			} else {
-				errs = append(errs, result.err.Error())
-			}
+		if result.error != nil {
+			errs = append(errs, result.error.Error())
 		}
-		if result.obj != nil {
-			children = append(children, configObject{
-				object:   result.obj,
-				required: result.metadata.required,
-				allKeys:  result.metadata.allKeys,
-				keys:     result.metadata.keys,
-			})
+		if result.Object != nil {
+			if s, ok := result.Object.(*corev1.Secret); ok {
+				secrets[result.NamespacedName] = s
+			} else if cm, ok := result.Object.(*corev1.ConfigMap); ok {
+				configMaps[result.NamespacedName] = cm
+			} else {
+				return nil, nil, fmt.Errorf("passed unknown type: %v", reflect.TypeOf(result.Object))
+			}
 		}
 	}
 
 	// If there were any errors, don't return any children
 	if len(errs) > 0 {
-		return []configObject{}, fmt.Errorf("error(s) encountered when geting children: %s", strings.Join(errs, ", "))
-	}
-
-	// If there we did not find required elements
-	if len(notFoundErrs) > 0 {
-		return []configObject{}, &NotFoundError{fmt.Sprintf("required children not found: %s", strings.Join(notFoundErrs, ", "))}
+		return nil, nil, fmt.Errorf("error(s) encountered when geting children: %s", strings.Join(errs, ", "))
 	}
 
 	// No errors, return the list of children
-	return children, nil
+	return configMaps, secrets, nil
 }
 
 // getChildNamesByType parses the Deployment object and returns two maps,
 // the first containing ConfigMap metadata for all referenced ConfigMaps, keyed on the name of the ConfigMap,
 // the second containing Secret metadata for all referenced Secrets, keyed on the name of the Secrets
-func getChildNamesByType[I InstanceType](obj I) (configMetadataMap, configMetadataMap) {
+func getChildNamesByType[I InstanceType](obj I) (configMetadataList, configMetadataList) {
 	// Create sets for storing the names fo the ConfigMaps/Secrets
-	configMaps := make(configMetadataMap)
-	secrets := make(configMetadataMap)
+	configMaps := configMetadataList{}
+	secrets := configMetadataList{}
 
 	// Range through all Volumes and check the VolumeSources for ConfigMaps
 	// and Secrets
 	for _, vol := range GetPodTemplate(obj).Spec.Volumes {
 		if cm := vol.VolumeSource.ConfigMap; cm != nil {
-			configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())] = configMetadata{required: isRequired(cm.Optional), allKeys: true}
+			configMaps = append(configMaps, configMetadata{required: isRequired(cm.Optional), allKeys: true, name: GetNamespacedName(cm.Name, obj.GetNamespace())})
 		}
 		if s := vol.VolumeSource.Secret; s != nil {
-			secrets[GetNamespacedName(s.SecretName, obj.GetNamespace())] = configMetadata{required: isRequired(s.Optional), allKeys: true}
+			secrets = append(secrets, configMetadata{required: isRequired(s.Optional), allKeys: true, name: GetNamespacedName(s.SecretName, obj.GetNamespace())})
 		}
 
 		if projection := vol.VolumeSource.Projected; projection != nil {
 			for _, source := range projection.Sources {
 				if cm := source.ConfigMap; cm != nil {
 					if cm.Items == nil {
-						configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())] = configMetadata{required: isRequired(cm.Optional), allKeys: true}
+						configMaps = append(configMaps, configMetadata{required: isRequired(cm.Optional), allKeys: true, name: GetNamespacedName(cm.Name, obj.GetNamespace())})
 					} else {
 						keys := make(map[string]struct{})
 						for _, item := range cm.Items {
 							keys[item.Key] = struct{}{}
 						}
-						configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())] = configMetadata{required: isRequired(cm.Optional), allKeys: false, keys: keys}
+						configMaps = append(configMaps, configMetadata{required: isRequired(cm.Optional), allKeys: false, keys: keys, name: GetNamespacedName(cm.Name, obj.GetNamespace())})
 					}
 				}
 				if s := source.Secret; s != nil {
 					if s.Items == nil {
-						secrets[GetNamespacedName(s.Name, obj.GetNamespace())] = configMetadata{required: isRequired(s.Optional), allKeys: true}
+						secrets = append(secrets, configMetadata{required: isRequired(s.Optional), allKeys: true, name: GetNamespacedName(s.Name, obj.GetNamespace())})
 					} else {
 						keys := make(map[string]struct{})
 						for _, item := range s.Items {
 							keys[item.Key] = struct{}{}
 						}
-						secrets[GetNamespacedName(s.Name, obj.GetNamespace())] = configMetadata{required: isRequired(s.Optional), allKeys: false, keys: keys}
+						secrets = append(secrets, configMetadata{required: isRequired(s.Optional), allKeys: false, keys: keys, name: GetNamespacedName(s.Name, obj.GetNamespace())})
 					}
 				}
 			}
 		}
+	}
 
-		// Parse deployment annotations for cms/secrets used inside the pod
-		if annotations := obj.GetAnnotations(); annotations != nil {
-			if configMapString, ok := annotations[ExtraConfigMapsAnnotation]; ok {
-				for _, cm := range strings.Split(configMapString, ",") {
-					parts := strings.Split(cm, "/")
-					if len(parts) == 1 {
-						configMaps[GetNamespacedName(parts[0], obj.GetNamespace())] = configMetadata{required: false, allKeys: true}
-					} else if len(parts) == 2 {
-						configMaps[GetNamespacedName(parts[1], parts[0])] = configMetadata{required: false, allKeys: true}
-					}
+	// Parse deployment annotations for cms/secrets used inside the pod
+	if annotations := obj.GetAnnotations(); annotations != nil {
+		if configMapString, ok := annotations[ExtraConfigMapsAnnotation]; ok {
+			for _, cm := range strings.Split(configMapString, ",") {
+				parts := strings.Split(cm, "/")
+				if len(parts) == 1 {
+					configMaps = append(configMaps, configMetadata{required: false, allKeys: true, name: GetNamespacedName(parts[0], obj.GetNamespace())})
+				} else if len(parts) == 2 {
+					configMaps = append(configMaps, configMetadata{required: false, allKeys: true, name: GetNamespacedName(parts[1], parts[0])})
 				}
 			}
-			if secretString, ok := annotations[ExtraSecretsAnnotation]; ok {
-				for _, secret := range strings.Split(secretString, ",") {
-					parts := strings.Split(secret, "/")
-					if len(parts) == 1 {
-						secrets[GetNamespacedName(parts[0], obj.GetNamespace())] = configMetadata{required: false, allKeys: true}
-					} else if len(parts) == 2 {
-						secrets[GetNamespacedName(parts[1], parts[0])] = configMetadata{required: false, allKeys: true}
-					}
+		}
+		if secretString, ok := annotations[ExtraSecretsAnnotation]; ok {
+			for _, secret := range strings.Split(secretString, ",") {
+				parts := strings.Split(secret, "/")
+				if len(parts) == 1 {
+					secrets = append(secrets, configMetadata{required: false, allKeys: true, name: GetNamespacedName(parts[0], obj.GetNamespace())})
+				} else if len(parts) == 2 {
+					secrets = append(secrets, configMetadata{required: false, allKeys: true, name: GetNamespacedName(parts[1], parts[0])})
 				}
 			}
 		}
@@ -188,10 +169,10 @@ func getChildNamesByType[I InstanceType](obj I) (configMetadataMap, configMetada
 	for _, container := range GetPodTemplate(obj).Spec.Containers {
 		for _, env := range container.EnvFrom {
 			if cm := env.ConfigMapRef; cm != nil {
-				configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())] = configMetadata{required: isRequired(cm.Optional), allKeys: true}
+				configMaps = append(configMaps, configMetadata{required: isRequired(cm.Optional), allKeys: true, name: GetNamespacedName(cm.Name, obj.GetNamespace())})
 			}
 			if s := env.SecretRef; s != nil {
-				secrets[GetNamespacedName(s.Name, obj.GetNamespace())] = configMetadata{required: isRequired(s.Optional), allKeys: true}
+				secrets = append(secrets, configMetadata{required: isRequired(s.Optional), allKeys: true, name: GetNamespacedName(s.Name, obj.GetNamespace())})
 			}
 		}
 	}
@@ -201,10 +182,16 @@ func getChildNamesByType[I InstanceType](obj I) (configMetadataMap, configMetada
 		for _, env := range container.Env {
 			if valFrom := env.ValueFrom; valFrom != nil {
 				if cm := valFrom.ConfigMapKeyRef; cm != nil {
-					configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())] = parseConfigMapKeyRef(configMaps[GetNamespacedName(cm.Name, obj.GetNamespace())], cm)
+					keys := map[string]struct{}{
+						cm.Key: {},
+					}
+					configMaps = append(configMaps, configMetadata{required: isRequired(cm.Optional), allKeys: false, keys: keys, name: GetNamespacedName(cm.Name, obj.GetNamespace())})
 				}
 				if s := valFrom.SecretKeyRef; s != nil {
-					secrets[GetNamespacedName(s.Name, obj.GetNamespace())] = parseSecretKeyRef(secrets[GetNamespacedName(s.Name, obj.GetNamespace())], s)
+					keys := map[string]struct{}{
+						s.Key: {},
+					}
+					secrets = append(secrets, configMetadata{required: isRequired(s.Optional), allKeys: false, keys: keys, name: GetNamespacedName(s.Name, obj.GetNamespace())})
 				}
 			}
 		}
@@ -213,65 +200,78 @@ func getChildNamesByType[I InstanceType](obj I) (configMetadataMap, configMetada
 	return configMaps, secrets
 }
 
+func (h *Handler[I]) checkRequiredChildren(configMaps map[types.NamespacedName]*corev1.ConfigMap, secrets map[types.NamespacedName]*corev1.Secret, configMapsConfig configMetadataList, secretsConfig configMetadataList) error {
+	errors := []string{}
+	for _, childConfig := range configMapsConfig {
+		if !childConfig.required {
+			continue
+		}
+		cm, ok := configMaps[childConfig.name]
+		if !ok {
+			errors = append(errors, fmt.Sprintf("missing required configmap %s/%s", childConfig.name.Namespace, childConfig.name.Name))
+			continue
+		}
+		if childConfig.keys != nil {
+			for key := range childConfig.keys {
+				_, inData := cm.Data[key]
+				_, inBinaryData := cm.BinaryData[key]
+				if !inData && !inBinaryData {
+					errors = append(errors, fmt.Sprintf("missing required key %s in configmap %s/%s", key, childConfig.name.Namespace, childConfig.name.Name))
+				}
+			}
+		}
+	}
+
+	for _, childConfig := range secretsConfig {
+		if !childConfig.required {
+			continue
+		}
+		s, ok := secrets[childConfig.name]
+		if !ok {
+			errors = append(errors, fmt.Sprintf("missing required secret %s/%s", childConfig.name.Namespace, childConfig.name.Name))
+			continue
+		}
+		if childConfig.keys != nil {
+			for key := range childConfig.keys {
+				if _, ok := s.Data[key]; !ok {
+					errors = append(errors, fmt.Sprintf("missing required key %s in secret %s/%s", key, childConfig.name.Namespace, childConfig.name.Name))
+				}
+			}
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("not all required children exist: %s", strings.Join(errors, ", "))
+	}
+	return nil
+}
+
 func isRequired(b *bool) bool {
 	return b == nil || !*b
 }
 
-// parseConfigMapKeyRef updates the metadata for a ConfigMap to include the keys specified in this ConfigMapKeySelector
-func parseConfigMapKeyRef(metadata configMetadata, cm *corev1.ConfigMapKeySelector) configMetadata {
-	if !metadata.allKeys {
-		if metadata.keys == nil {
-			metadata.keys = make(map[string]struct{})
-		}
-		if cm.Optional == nil || !*cm.Optional {
-			metadata.required = true
-		}
-		metadata.keys[cm.Key] = struct{}{}
-	}
-	return metadata
-}
-
-// parseSecretKeyRef updates the metadata for a Secret to include the keys specified in this SecretKeySelector
-func parseSecretKeyRef(metadata configMetadata, s *corev1.SecretKeySelector) configMetadata {
-	if !metadata.allKeys {
-		if metadata.keys == nil {
-			metadata.keys = make(map[string]struct{})
-		}
-		if s.Optional == nil || !*s.Optional {
-			metadata.required = true
-		}
-		metadata.keys[s.Key] = struct{}{}
-	}
-	return metadata
-}
-
 // getConfigMap gets a ConfigMap with the given name and namespace from the
 // API server.
-func (h *Handler[I]) getConfigMap(name types.NamespacedName, metadata configMetadata) getResult {
-	return h.getObject(name, metadata, &corev1.ConfigMap{})
+func (h *Handler[I]) getConfigMap(name types.NamespacedName) getResult {
+	return h.getObject(name, &corev1.ConfigMap{})
 }
 
 // getSecret gets a Secret with the given name and namespace from the
 // API server.
-func (h *Handler[I]) getSecret(name types.NamespacedName, metadata configMetadata) getResult {
-	return h.getObject(name, metadata, &corev1.Secret{})
+func (h *Handler[I]) getSecret(name types.NamespacedName) getResult {
+	return h.getObject(name, &corev1.Secret{})
 }
 
 // getObject gets the Object with the given name and namespace from the API
 // server
-func (h *Handler[I]) getObject(objectName types.NamespacedName, metadata configMetadata, obj Object) getResult {
-	err := h.Get(context.TODO(), objectName, obj)
+func (h *Handler[I]) getObject(name types.NamespacedName, obj Object) getResult {
+	err := h.Get(context.TODO(), name, obj)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			if metadata.required {
-				return getResult{err: err, notFound: true}
-			}
-			return getResult{metadata: metadata, notFound: true}
-		} else {
-			return getResult{err: err, notFound: false}
+			return getResult{nil, name, nil}
 		}
+		return getResult{nil, name, err}
 	}
-	return getResult{obj: obj, metadata: metadata, notFound: false}
+	return getResult{obj, name, nil}
 }
 
 // getExistingChildren returns a list of all Secrets and ConfigMaps that are

--- a/pkg/core/finalizer.go
+++ b/pkg/core/finalizer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package core
 
 // removeFinalizer removes the wave finalizer from the given podController
+//
+// Deprecated: Wave no longer uses finalizers. Only used for migration.
 func removeFinalizer[I InstanceType](obj I) {
 	finalizers := obj.GetFinalizers()
 
@@ -33,6 +35,8 @@ func removeFinalizer[I InstanceType](obj I) {
 }
 
 // hasFinalizer checks for the presence of the Wave finalizer
+//
+// Deprecated: Wave no longer uses finalizers. Only used for migration.
 func hasFinalizer[I InstanceType](obj I) bool {
 	finalizers := obj.GetFinalizers()
 	for _, finalizer := range finalizers {

--- a/pkg/core/handler_test.go
+++ b/pkg/core/handler_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Wave controller Suite", func() {
 				eventMessage := func(event *corev1.Event) string {
 					return event.Message
 				}
-				hashMessage := "Configuration hash updated to 421778c325761f51dbf7a23a20eb9c1bc516ffd4aa7362ebec03175d427d7557"
+				hashMessage := "Configuration hash updated to 318d4a3c6b9f6471f054001ea3103b2abb3693fe41922c733df45b53266d5216"
 				Eventually(func() *corev1.EventList {
 					events := &corev1.EventList{}
 					m.Client.List(context.TODO(), events)

--- a/pkg/core/owner_references.go
+++ b/pkg/core/owner_references.go
@@ -28,6 +28,8 @@ import (
 
 // removeOwnerReferences iterates over a list of children and removes the owner
 // reference from the child before updating it
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func (h *Handler[I]) removeOwnerReferences(obj I, children []Object) error {
 	for _, child := range children {
 		// Filter the existing ownerReferences

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -52,15 +52,6 @@ type Object interface {
 	metav1.Object
 }
 
-// configObject is used as a container of an "Object" along with metadata
-// that Wave uses to determine what to use from that Object.
-type configObject struct {
-	object   Object
-	required bool
-	allKeys  bool
-	keys     map[string]struct{}
-}
-
 type InstanceType interface {
 	*appsv1.Deployment | *appsv1.StatefulSet | *appsv1.DaemonSet
 	client.Object
@@ -72,6 +63,20 @@ type DeplyomentInterface interface {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 }
+
+// configMetadata contains information about ConfigMaps/Secrets referenced
+// within PodTemplates
+//
+// maps of configMetadata are return from the getChildNamesByType method
+// configMetadata is also used to pass info through the getObject methods
+type configMetadata struct {
+	name     types.NamespacedName
+	required bool
+	allKeys  bool
+	keys     map[string]struct{}
+}
+
+type configMetadataList []configMetadata
 
 func GetPodTemplate[I InstanceType](instance I) *corev1.PodTemplateSpec {
 	if deployment, ok := any(instance).(*appsv1.Deployment); ok {

--- a/test/utils/owner_ref.go
+++ b/test/utils/owner_ref.go
@@ -22,6 +22,8 @@ import (
 )
 
 // GetOwnerRefDeployment constructs an owner reference for the Deployment given
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func GetOwnerRefDeployment(deployment *appsv1.Deployment) metav1.OwnerReference {
 	f := false
 	t := true
@@ -36,6 +38,8 @@ func GetOwnerRefDeployment(deployment *appsv1.Deployment) metav1.OwnerReference 
 }
 
 // GetOwnerRefStatefulSet constructs an owner reference for the StatefulSet given
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func GetOwnerRefStatefulSet(sts *appsv1.StatefulSet) metav1.OwnerReference {
 	f := false
 	t := true
@@ -50,6 +54,8 @@ func GetOwnerRefStatefulSet(sts *appsv1.StatefulSet) metav1.OwnerReference {
 }
 
 // GetOwnerRefDaemonSet constructs an owner reference for the DaemonSet given
+//
+// Deprecated: Wave no longer uses OwnerReferences. Only used for migration.
 func GetOwnerRefDaemonSet(sts *appsv1.DaemonSet) metav1.OwnerReference {
 	f := false
 	t := true

--- a/test/utils/test_objects.go
+++ b/test/utils/test_objects.go
@@ -119,11 +119,11 @@ var podTemplate = &corev1.PodTemplateSpec{
 								},
 								Items: []corev1.KeyToPath{
 									{
-										Key:  "example6_key1",
+										Key:  "key1",
 										Path: "example6_key1.txt",
 									},
 									{
-										Key:  "example6_key3",
+										Key:  "key3",
 										Path: "example6_key3.txt",
 									},
 								},
@@ -143,11 +143,11 @@ var podTemplate = &corev1.PodTemplateSpec{
 								},
 								Items: []corev1.KeyToPath{
 									{
-										Key:  "example6_key1",
+										Key:  "key1",
 										Path: "example6_key1.txt",
 									},
 									{
-										Key:  "example6_key3",
+										Key:  "key3",
 										Path: "example6_key3.txt",
 									},
 								},
@@ -505,6 +505,19 @@ var ExampleConfigMap6 = &corev1.ConfigMap{
 		"key1": "example6:key1",
 		"key2": "example6:key2",
 		"key3": "example6:key3",
+	},
+}
+
+// ExampleConfigMap6 is an example ConfigMap object for use within test suites
+var ExampleConfigMap6WithoutKey3 = &corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "example6",
+		Namespace: "default",
+		Labels:    labels,
+	},
+	Data: map[string]string{
+		"key1": "example6:key1",
+		"key2": "example6:key2",
 	},
 }
 


### PR DESCRIPTION
- Properly track all children
- Do not overwrite children if they are referenced multiple times
- Track which keys are required and which are optional in a configmap/secret
- Validate if our children have all required key (before: we only checked that the child existed)
- Add logging + kubernetes events for scheduling enable/disable
- Fix potential race in watcher code. We previously released the lock during watcher updates. There is a small chance that we might miss an updated child in a concurrent watcher. Not a huge chance but not impossible.

Fix #170
Fix #171
Fix #172 

This fixes a few cases we found in production where pods were restarting after creation (in combination with cert-manager secrets which initiall miss a key). Other than that it performed very well.

On top of #169. We might want to merge that first.
